### PR TITLE
Fix localised Chrome

### DIFF
--- a/epicgames.js
+++ b/epicgames.js
@@ -29,9 +29,12 @@ function register(){
 
   (async () => {
 
+  var options = new chrome.Options();
+  options.addArguments('disable-gpu');
+  options.addArguments("--lang=en-US");
 
   try{
-    driver = new Builder().forBrowser('chrome').build();
+    driver = new Builder().forBrowser('chrome').setChromeOptions(options).build();
 	var date = new Date(Date.now())
     await driver.get('https://www.epicgames.com/id/register');
     await   driver.wait(until.titleIs('Register for an Epic Games account | Epic Games'), 5000);


### PR DESCRIPTION
1. force webdriver locale to EN
this fixes not found title strings for non-english users

2. disable GPU usage for Web-GL
fixes errors on old or weird devices